### PR TITLE
[Feat] 대화 상자 버튼 색상 변경

### DIFF
--- a/meant/meant/Common/Extensions/UIViewController+.swift
+++ b/meant/meant/Common/Extensions/UIViewController+.swift
@@ -15,14 +15,16 @@ extension UIViewController {
         leftActionText: String,
         rightActionText: String,
         leftActionCompletion: (() -> Void)? = nil,
-        rightActionCompletion: (() -> Void)? = nil
+        rightActionCompletion: (() -> Void)? = nil,
+        isRightDangerous: Bool = false
     ) {
         let alertViewController = MeantAlertViewController(
             message: message,
             leftActionText: leftActionText,
             rightActionText: rightActionText,
             leftActionCompletion: leftActionCompletion,
-            rightActionCompletion: rightActionCompletion
+            rightActionCompletion: rightActionCompletion,
+            isRightDangerous: isRightDangerous
         )
         present(alertViewController, animated: false)
     }

--- a/meant/meant/Data/UserSettingsRepository.swift
+++ b/meant/meant/Data/UserSettingsRepository.swift
@@ -20,7 +20,7 @@ final class UserSettingsRepository: UserSettingsRepositoryInterface {
     @UserDefaultsData(key: "notificationTime", defaultValue: Date().date(from: "21:00"))
     var notificationTime: Date
     
-    @UserDefaultsData(key: "notificationMessage", defaultValue: "하루의 의미를 찾을 시간이에요. 🍃")
+    @UserDefaultsData(key: "notificationMessage", defaultValue: "기록은 기억을 남긴다 🍃")
     var notificationMessage: String
     
     @UserDefaultsData(key: "lastAccessDate", defaultValue: Date())

--- a/meant/meant/Presentation/Common/MeantAlertViewController.swift
+++ b/meant/meant/Presentation/Common/MeantAlertViewController.swift
@@ -55,7 +55,8 @@ final class MeantAlertViewController: UIViewController {
         leftActionText: String,
         rightActionText: String,
         leftActionCompletion: (() -> Void)? = nil,
-        rightActionCompletion: (() -> Void)? = nil
+        rightActionCompletion: (() -> Void)? = nil,
+        isRightDangerous: Bool = false
     ) {
         super.init(nibName: nil, bundle: nil)
         
@@ -69,6 +70,10 @@ final class MeantAlertViewController: UIViewController {
             leftActionCompletion: leftActionCompletion,
             rightActionCompletion: rightActionCompletion
         )
+        
+        if isRightDangerous {
+            rightButton.tintColor = .alertWarning
+        }
     }
     
     init(message: String, actionText: String, actionCompletion: (() -> Void)? = nil) {
@@ -163,6 +168,7 @@ final class MeantAlertViewController: UIViewController {
         let button = UIButton()
         button.configuration = .plain()
         button.backgroundColor = .clear
+        button.tintColor = .alertSuccess
         return button
     }
     

--- a/meant/meant/Presentation/Edit/EditViewController.swift
+++ b/meant/meant/Presentation/Edit/EditViewController.swift
@@ -67,7 +67,8 @@ final class EditViewController: BaseViewController<EditView> {
             rightActionText: "취소하기",
             rightActionCompletion: { [weak self] in
                 self?.dismiss(animated: true)
-            }
+            },
+            isRightDangerous: true
         )
     }
     

--- a/meant/meant/Presentation/Home/HomeViewController.swift
+++ b/meant/meant/Presentation/Home/HomeViewController.swift
@@ -254,7 +254,7 @@ extension HomeViewController: UITableViewDelegate {
         }
         deleteAction.backgroundColor = .white
         
-        let imageConfig = UIImage.SymbolConfiguration(pointSize: 10, weight: .bold)
+        let imageConfig = UIImage.SymbolConfiguration(pointSize: 8, weight: .bold)
         let image = UIImage(systemName: "trash", withConfiguration: imageConfig)?.withTintColor(.alertWarning, renderingMode: .alwaysOriginal)
         deleteAction.image = image
         
@@ -349,7 +349,8 @@ extension HomeViewController: RecordMenuViewDelegate {
                     guard let self = self else { return }
                     viewModel.deleteRandomRecord()
                     dismiss(animated: true)
-                }
+                },
+                isRightDangerous: true
             )
         }
     }

--- a/meant/meant/Presentation/Record/RecordViewController.swift
+++ b/meant/meant/Presentation/Record/RecordViewController.swift
@@ -54,16 +54,21 @@ final class RecordViewController: BaseViewController<RecordView> {
     
     @objc private func handleCancelButtonTap() {
         generateHaptic()
-        showAlert(
-            message: recordType == .confide ?
-            "아직 다 적지 않은 이야기가 있어요.\n정말 나가시겠어요?" :
-            "소중한 조각들이 잊혀질지도 몰라요.\n정말 나가시겠어요?",
-            leftActionText: "머무르기",
-            rightActionText: "나가기",
-            rightActionCompletion: { [weak self] in
-                self?.navigationController?.popViewController(animated: true)
-            }
-        )
+        if textView.text.isEmpty {
+            navigationController?.popViewController(animated: true)
+        } else {
+            showAlert(
+                message: recordType == .confide ?
+                "아직 다 적지 않은 이야기가 있어요.\n정말 나가시겠어요?" :
+                "소중한 조각들이 잊혀질지도 몰라요.\n정말 나가시겠어요?",
+                leftActionText: "머무르기",
+                rightActionText: "나가기",
+                rightActionCompletion: { [weak self] in
+                    self?.navigationController?.popViewController(animated: true)
+                },
+                isRightDangerous: true
+            )
+        }
     }
     
     @objc private func handleDoneButtonTap() {

--- a/meant/meant/Presentation/RecordDetail/RecordDetailViewController.swift
+++ b/meant/meant/Presentation/RecordDetail/RecordDetailViewController.swift
@@ -163,7 +163,7 @@ extension RecordDetailViewController: UITableViewDelegate {
         }
         deleteAction.backgroundColor = .white
         
-        let imageConfig = UIImage.SymbolConfiguration(pointSize: 10, weight: .bold)
+        let imageConfig = UIImage.SymbolConfiguration(pointSize: 8, weight: .bold)
         let image = UIImage(systemName: "trash", withConfiguration: imageConfig)?.withTintColor(.alertWarning, renderingMode: .alwaysOriginal)
         deleteAction.image = image
         
@@ -208,7 +208,8 @@ extension RecordDetailViewController: RecordMenuViewDelegate {
                     removeNotificationObserver()
                     viewModel.deleteRecord()
                     navigationController?.popViewController(animated: true)
-                }
+                },
+                isRightDangerous: true
             )
         default:
             break

--- a/meant/meant/Presentation/Settings/SettingsViewController.swift
+++ b/meant/meant/Presentation/Settings/SettingsViewController.swift
@@ -110,7 +110,8 @@ extension SettingsViewController: UITableViewDelegate {
                 rightActionCompletion: {
                     NotificationCenter.default.post(name: .recordsDidReset, object: nil)
                     self.navigationController?.popViewController(animated: true)
-                }
+                },
+                isRightDangerous: true
             )
         case .lisence:
             let licenseViewController = LicenseViewController()


### PR DESCRIPTION
### ☁️  개요
<!-- PR의 목적과 해결하고자 하는 문제 -->
사용자에게 경고를 주기 위해 대화 상자 버튼의 색상을 변경할 수 있는 기능을 추가합니다.

### 💻 작업 내용
<!-- 작업한 내용 bullet point로 나열 -->

|![image](https://github.com/user-attachments/assets/f500a3c0-1db6-49d8-80ac-720622fb0d72)|![image](https://github.com/user-attachments/assets/e9814623-e5b9-4f15-9c50-bd1b325b93bc)|![image](https://github.com/user-attachments/assets/fb6f9cb5-0636-4df5-be9d-5996bb84f272)|
|-|-|-|

+) 로컬 알림의 기본 문구를 변경

### 🔗 관련 이슈
<!-- 관련 이슈 번호 (예: closes #38) -->
closes #42 
